### PR TITLE
Ignore .vagrant dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant


### PR DESCRIPTION
@dbaba .vagrant contains meta information of container.  It should be ignored.
