### PR TITLE
Fix setup.sh, coping some scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can configure the kernel config as you like.
 
 You can reset the kernel config modifications by the following command.
 ```bash
-(vagrant)$ ./config_rset.sh
+(vagrant)$ ./config_reset.sh
 ~/edison/edison-src/meta-intel-edison/meta-intel-edison-bsp/recipes-kernel/linux/files ~
 Resetting configuration
 [defconfig]

--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,7 @@ cd /home/vagrant/edison/edison-src
 mkdir bitbake_download_dir bitbake_sstate_dir
 ./meta-intel-edison/setup.sh --dl_dir=./bitbake_download_dir --sstate_dir=./bitbake_sstate_dir
 
-cp /vagrant/bake.sh /home/vagrant/
+cp /vagrant/build.sh /home/vagrant/
 cp /vagrant/config_get.sh /home/vagrant/
 cp /vagrant/config_set.sh /home/vagrant/
 

--- a/setup.sh
+++ b/setup.sh
@@ -34,5 +34,6 @@ mkdir bitbake_download_dir bitbake_sstate_dir
 cp /vagrant/build.sh /home/vagrant/
 cp /vagrant/config_get.sh /home/vagrant/
 cp /vagrant/config_set.sh /home/vagrant/
+cp /vagrant/config_reset.sh /home/vagrant/
 
 chown -R vagrant:vagrant /home/vagrant/


### PR DESCRIPTION
setup.sh try to copy bake.sh, but it does not exist.  I think it stand for build.sh, so build.sh will be copied instead of bake.sh
also, config_reset script will be copied to home directory.  it's required to keep consistency with README.md.
